### PR TITLE
Fixed bug involving selecting by aspect ratio

### DIFF
--- a/cropduster/models.py
+++ b/cropduster/models.py
@@ -49,7 +49,7 @@ class SizeManager(models.Manager):
 			size = size_query[aspect_ratio_id]
 			
 			# get the largest size with this aspect ratio
-			return Size.objects.all().filter(aspect_ratio=size.aspect_ratio, auto_size=False).order_by("-width")[0]
+			return Size.objects.all().filter(size_set=size_set, aspect_ratio=size.aspect_ratio, auto_size=False).order_by("-width")[0]
 		except:
 			return None
 


### PR DESCRIPTION
It was requiring the image to be larger than the largest image in the DB with that aspect ratio rather than the largest in the size set.

Also, I didn't make the connection as to why this was fixed as well, but this was apparently also the reason my images were saving to every size from another size set's sizes of comparable ratio.
