### PR TITLE
This fixes a bug where sometimes self.box.aspect_ratio would be a negati...

### DIFF
--- a/cropduster/resizing.py
+++ b/cropduster/resizing.py
@@ -213,7 +213,7 @@ class Crop(object):
         else:
             aspect_ratio = self.box.aspect_ratio
 
-        scale = math.sqrt(aspect_ratio / self.box.aspect_ratio)
+        scale = math.sqrt(math.fabs(aspect_ratio / self.box.aspect_ratio))
 
         w = self.box.w * scale
         h = w / aspect_ratio


### PR DESCRIPTION
This fixes a bug where sometimes self.box.aspect_ratio would be a negative number, which throws an error when you try and set scale by getting the square root of a negative number.

I'm not 100% sure why scale is set this way to begin with or if `self.box.aspect_ratio` being negative is a problem in and of itself, hence the pull request.
