### PR TITLE
Explicitely return if db.dry_run is set in migration 0004.

### DIFF
--- a/cropduster/migrations/0004_add_auto_thumb_m2m_rows.py
+++ b/cropduster/migrations/0004_add_auto_thumb_m2m_rows.py
@@ -7,6 +7,9 @@ from django.db import models
 class Migration(DataMigration):
     
     def forwards(self, orm):
+        if db.dry_run:
+            return
+
         Thumb = orm['cropduster.Thumb']
         Image = orm['cropduster.Image']
         M2M = Image.thumbs.through


### PR DESCRIPTION
Our version of south will run a migration regardless of whether db.dry_run is
set on MySQL. This tries to ensure that the migration can run correctly without
transactions because the RDBMS will not roll back properly.

We need this for tests to run properly.

See: https://github.com/theatlantic/django-south/blob/master/south/migration/migrators.py#L106-L113
