### PR TITLE
A templatetag for cropduster v3 that mirrors the one we use in v4.

### DIFF
--- a/cropduster/__init__.py
+++ b/cropduster/__init__.py
@@ -1,4 +1,4 @@
-__version_info__ = (4, 2, 25)
+__version_info__ = (4, 2, 26)
 __version__ = '.'.join(map(str, __version_info__))
 
 # Import these into module root for API simplicity

--- a/cropduster3/templatetags/cropdusterimages.py
+++ b/cropduster3/templatetags/cropdusterimages.py
@@ -28,3 +28,35 @@ def get_image(image, size_name='large', template_name='image.html',
     tpl = template.loader.get_template('templatetags/' + template_name)
     ctx = template.Context(kwargs)
     return tpl.render(ctx)
+
+
+@register.assignment_tag
+def get_v3_crop(image, crop_name, size=None):
+    """
+    This uses the same API as the v4 get_crop for easy upgrading.
+    
+    Get the crop of an image. Usage:
+
+    {% get_v3_crop article.image 'square_thumbnail' as size=1 %}
+
+    will return a dictionary of
+
+    {
+        "url": /media/path/to/my.jpg,
+        "width": 150,
+        "height" 150,
+    }
+
+    For use in an image tag or style block.
+
+    Omitting the `size` kwarg will omit width and height. You usually want to do this,
+    since the size lookup is a database call.
+    """
+    data = {}
+    crop = image.get_thumbnail(crop_name)
+    if crop:
+        data['url'] = crop.image.url
+    if size:
+        data['width'] = crop.width
+        data['height'] = crop.height
+    return data


### PR DESCRIPTION
Since v3->4 migrators are basically ready to go, it seems dumb to
start referring to images in a way that won't be forwards-compatible.

The code is identical, I just wanted to check if anyone had objections.
