### PR TITLE
Base JPEG quality off the size of the thumb, not the original.

### DIFF
--- a/cropduster/models.py
+++ b/cropduster/models.py
@@ -272,6 +272,7 @@ class Image(models.Model):
             h = int(round(orig_h * resize_ratio))
             preview_img = pil_img.resize((w, h), PIL.Image.ANTIALIAS)
         else:
+            w, h = orig_w, orig_h
             preview_img = pil_img
         preview_file = cls.get_file_for_size(image_file, '_preview')
         img_save_params = {}

--- a/cropduster/utils/image.py
+++ b/cropduster/utils/image.py
@@ -177,7 +177,7 @@ def process_image(im, save_filename=None, callback=lambda i: i, nq=0, save_param
         else:
             save_params = save_params or {}
             if im.format == 'JPEG':
-                save_params.setdefault('quality', get_jpeg_quality(im.size[0], im.size[1]))
+                save_params.setdefault('quality', get_jpeg_quality(new_images[0].size[0], new_images[0].size[1]))
             new_images[0].save(save_filename, **save_params)
 
         return PIL.Image.open(save_filename)


### PR DESCRIPTION
This was causing all images to have freakishly low compression.