### PR TITLE
`get_crop` returns None if there is no corresponding cropduster image

### DIFF
--- a/cropduster/templatetags/cropduster_tags.py
+++ b/cropduster/templatetags/cropduster_tags.py
@@ -65,7 +65,9 @@ def get_crop(image, crop_name, exact_size=False, **kwargs):
 
             if size.height:
                 data['height'] = size.height
-    elif image.related_object:
+    elif not image.related_object:
+        return None
+    else:
         thumbs = {thumb.name: thumb for thumb in image.related_object.thumbs.all()}
 
         try:


### PR DESCRIPTION
Cropduster was returning broken images for image fields without a corresponding Cropduster Image row (ie, rows that had been converted into a normal image row).