### PR TITLE
Permissive does not catch some errors.

### DIFF
--- a/cropduster/models.py
+++ b/cropduster/models.py
@@ -430,12 +430,13 @@ class Image(models.Model):
 
         for sz in Size.flatten([size]):
             try:
-                if sz.is_auto:
+                if thumb and sz.is_auto:
                     new_thumb = self._save_thumb(sz, image, ref_thumb=thumb, tmp=tmp)
                 else:
                     thumb = new_thumb = self._save_thumb(sz, image, thumb, tmp=tmp)
-            except (CropDusterResizeException, ValueError):
+            except CropDusterResizeException:
                 if permissive or not sz.required:
+                    thumb = new_thumb = None
                     continue
                 else:
                     raise

--- a/cropduster/models.py
+++ b/cropduster/models.py
@@ -434,7 +434,7 @@ class Image(models.Model):
                     new_thumb = self._save_thumb(sz, image, ref_thumb=thumb, tmp=tmp)
                 else:
                     thumb = new_thumb = self._save_thumb(sz, image, thumb, tmp=tmp)
-            except CropDusterResizeException:
+            except (CropDusterResizeException, ValueError):
                 if permissive or not sz.required:
                     continue
                 else:


### PR DESCRIPTION
This fixes the problem that I'm encountering, where
images which are too small are generating errors for
author.image.generate_thumbs(permissive=True)