### PR TITLE
Ckeditor Image plugin actually already had an alt text field.

### DIFF
--- a/cropduster/standalone/static/ckeditor/ckeditor/plugins/cropduster/dialogs/cropduster.js
+++ b/cropduster/standalone/static/ckeditor/ckeditor/plugins/cropduster/dialogs/cropduster.js
@@ -474,6 +474,18 @@ CKEDITOR.dialog.add('cropduster', function (editor) {
         }
     }
 
+    tabElements.push({
+        id: 'alt',
+        type: 'text',
+        label: lang.alt,
+        setup: function (widget) {
+            this.setValue(widget.data.alt);
+        },
+        commit: function (widget) {
+            widget.setData('alt', this.getValue());
+        }
+    });
+
     return {
         title: lang.title,
         minWidth: 650,
@@ -544,16 +556,6 @@ CKEDITOR.dialog.add('cropduster', function (editor) {
                 },
                 validate: function() {
                     return true;
-                }
-            }, {
-                id: 'alt',
-                type: 'text',
-                label: lang.alt,
-                setup: function (widget) {
-                    this.setValue(widget.data.alt);
-                },
-                commit: function (widget) {
-                    widget.setData('alt', this.getValue());
                 }
             }, {
                 type: 'hbox',


### PR DESCRIPTION
Let's make it visible.

<img width="699" alt="screenshot 2016-07-25 17 29 23" src="https://cloud.githubusercontent.com/assets/377630/17118113/617c9498-528d-11e6-8989-8ae5eb197fc3.png">
