### PR TITLE
`get_upload_foldername` was going too far in mangling hyphens

### DIFF
--- a/cropduster/tests/test_utils.py
+++ b/cropduster/tests/test_utils.py
@@ -74,6 +74,17 @@ class TestUtilsPaths(CropdusterTestCaseMediaMixin, test.TestCase):
                          os.path.join(path, 'my_img-1'))
         shutil.rmtree(path)
 
+    def test_get_upload_foldername_with_hyphens_and_underscores(self):
+        import uuid
+        from ..utils import get_upload_foldername
+
+        random = uuid.uuid4().hex
+        random = '--__-'.join((random[0:5], random[5:]))
+        path = os.path.join(settings.MEDIA_ROOT, random)
+        self.assertEqual(get_upload_foldername('my img.jpg', upload_to=random),
+                         os.path.join(path, 'my_img'))
+        shutil.rmtree(path)
+
     def test_get_min_size(self):
         from ..utils import get_min_size
         from ..resizing import Size

--- a/cropduster/utils/paths.py
+++ b/cropduster/utils/paths.py
@@ -19,13 +19,14 @@ def get_upload_foldername(file_name, upload_to='%Y/%m'):
     file_field = FileField(upload_to=upload_to)
     if not file_name:
         file_name = 'no_name'
-    filename = file_field.generate_filename(None, file_name)
-    filename = re.sub(r'[_\-]+', '_', filename)
 
-    if six.PY2 and isinstance(filename, unicode):
-        filename = filename.encode('utf-8')
+    file_name_abs = os.path.split(file_field.generate_filename(None, file_name))
+    file_name_abs = os.path.join(file_name_abs[0], re.sub(r'[_\-]+', '_', file_name_abs[1]))
 
-    root_dir = os.path.splitext(filename)[0]
+    if six.PY2 and isinstance(file_name_abs, unicode):
+        file_name_abs = file_name_abs.encode('utf-8')
+
+    root_dir = os.path.splitext(file_name_abs)[0]
     root_dir = dir_name = os.path.join(settings.MEDIA_ROOT, root_dir)
     i = 1
     while os.path.exists(dir_name):


### PR DESCRIPTION
The function should only be replacing hyphens in the immediate
dir name (the one that holds the image being uploaded), not in the
base path. If you had a path like `/data/shared/my-path/images/...`,
the `my-path` part would become `my_path`, and this is not good.