### PR TITLE
Bump max_length on image path field

### DIFF
--- a/cropduster/models.py
+++ b/cropduster/models.py
@@ -224,7 +224,8 @@ class Image(models.Model):
 
     image = CropDusterSimpleImageField(db_index=True,
         upload_to=generate_filename, db_column='path',
-        width_field='width', height_field='height')
+        width_field='width', height_field='height',
+        max_length=255)
 
     thumbs = ReverseForeignRelation(Thumb, field_name='image')
 


### PR DESCRIPTION
Some older cropduster forks (like ours) have a max length of 255
on the corresponding field. Making this 255 allows for a cleaner
migration; also, why not?