### PR TITLE
Fix Python 3 issue with sizes_callable

### DIFF
--- a/cropduster/forms.py
+++ b/cropduster/forms.py
@@ -34,7 +34,10 @@ class CropDusterWidget(GenericForeignFileWidget):
         if six.callable(sizes):
             instance = getattr(getattr(bound_field, 'form', None), 'instance', None)
             related_object = ctx['instance']
-            sizes_callable = getattr(sizes, 'im_func', sizes)
+            try:
+                sizes_callable = six.get_method_function(sizes)
+            except AttributeError:
+                sizes_callable = sizes
             sizes = sizes_callable(instance, related=related_object)
         sizes = [s for s in sizes if not getattr(s, 'is_alias', False)]
         ctx.update({


### PR DESCRIPTION
In Python 3, I noticed an issue when defining sizes as a callable. Thanks to debugging help, looks like the issue was:

> `method.im_func` in python 3 returns the method, not the raw function (you need `__func__` for that), so it's calling it as `sizes_callable(self, instance, related=related_object)` and that second instance is effectively the related argument