### PR TITLE
Fix uploads in Chrome

### DIFF
--- a/cropduster/static/cropduster/js/jquery.form.js
+++ b/cropduster/static/cropduster/js/jquery.form.js
@@ -88,7 +88,7 @@ $.fn.ajaxSubmit = function(options) {
 		url:  url,
 		success: $.ajaxSettings.success,
 		type: this[0].getAttribute('method') || 'GET', // IE7 massage (see issue 57)
-		iframeSrc: /^https/i.test(window.location.href || '') ? 'javascript:false' : 'about:blank'
+		iframeSrc: 'about:blank'
 	}, options);
 
 	// hook for manipulating the form data before it is extracted;


### PR DESCRIPTION
Patches jquery.form per advice on this issue:

https://github.com/jquery-form/form/issues/571

Ajax doesn't support posting files, so before FormData, the only
way to upload a file without a page refresh was to create an iframe,
build a form in it, and submit that to the server in a way where it
could sync up with the data POSTed by ajax.

Chrome 83 has an issue with the fake src jquery.form was setting
on that iframe, and would cancel the request. With no image
uploaded to the server (but no error in js to treat as a blocking
error) the process would attempt to continue and hit an error
when it tries to access a file that doesn't exist.

FUN-2604