### PR TITLE
Save StandaloneImage crop metadata as Thumb instances

### DIFF
--- a/cropduster/standalone/static/ckeditor/ckeditor/plugins/cropduster/dialogs/cropduster.js
+++ b/cropduster/standalone/static/ckeditor/ckeditor/plugins/cropduster/dialogs/cropduster.js
@@ -344,7 +344,10 @@ CKEDITOR.dialog.add('cropduster', function (editor) {
 
     var okButton = CKEDITOR.dialog.okButton.override({
         onClick: function(evt) {
-            var $j = cropdusterIframe.iframeElement.$.contentWindow.$;
+            var contentWin = cropdusterIframe.iframeElement.$.contentWindow;
+            var $j = (typeof contentWin.django === 'object')
+              ? contentWin.django.jQuery
+              : contentWin.$;
             if ($j) {
                 var $cropButton = $j('#crop-button');
                 if ($j.length && !$cropButton.hasClass('disabled')) {

--- a/cropduster/tests/settings.py
+++ b/cropduster/tests/settings.py
@@ -1,8 +1,14 @@
 import os
-import django
 import uuid
 
+import django
+from django.utils.functional import lazy
+from django.urls import reverse
+
 from selenosis.settings import *
+
+
+lazy_reverse = lazy(reverse, str)
 
 
 if django.VERSION > (1, 11):
@@ -16,7 +22,10 @@ if django.VERSION > (1, 11):
 INSTALLED_APPS += (
     'generic_plus',
     'cropduster',
+    'cropduster.standalone',
     'cropduster.tests',
+    'cropduster.tests.test_standalone',
+    'ckeditor',
 )
 
 ROOT_URLCONF = 'cropduster.tests.urls'
@@ -31,3 +40,21 @@ if os.environ.get('S3') == '1':
     AWS_S3_SIGNATURE_VERSION = 's3v4'
 else:
     DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
+
+CKEDITOR_CONFIGS = {
+    'default': {
+        'extraPlugins': 'cropduster',
+        'removePlugins': 'flash,forms,contextmenu,liststyle,table,tabletools,iframe',
+        'disableAutoInline': True,
+        "height": 450,
+        "width": 840,
+        'cropduster_uploadTo': 'ckeditor',
+        'cropduster_previewSize': [570, 300],
+        'cropduster_url': lazy_reverse('cropduster-standalone'),
+        'cropduster_urlParams': {'max_w': 672, 'full_w': 960},
+    },
+}
+
+CKEDITOR_UPLOAD_PATH = "%s/upload" % MEDIA_ROOT
+
+os.makedirs(CKEDITOR_UPLOAD_PATH)

--- a/cropduster/tests/test_admin.py
+++ b/cropduster/tests/test_admin.py
@@ -27,6 +27,7 @@ class TestAdmin(CropdusterTestCaseMediaMixin, AdminSelenosisTestCase):
             'generic_plus',
             'cropduster',
             'cropduster.tests',
+            'cropduster.tests.test_standalone',
             'selenosis',
         ]
         if self.has_grappelli:

--- a/cropduster/tests/test_standalone/admin.py
+++ b/cropduster/tests/test_standalone/admin.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+
+from .models import Article
+
+
+admin.site.register(Article)

--- a/cropduster/tests/test_standalone/models.py
+++ b/cropduster/tests/test_standalone/models.py
@@ -1,0 +1,7 @@
+from django.db import models
+
+from ckeditor.fields import RichTextField
+
+
+class Article(models.Model):
+    content = RichTextField(blank=True, config_name='default')

--- a/cropduster/tests/urls.py
+++ b/cropduster/tests/urls.py
@@ -8,6 +8,7 @@ admin.autodiscover()
 
 urlpatterns = [
     url(r"^cropduster/", include("cropduster.urls")),
+    url(r'^ckeditor/', include('ckeditor.urls')),
 ]
 
 if django.VERSION < (1, 9):

--- a/cropduster/views/__init__.py
+++ b/cropduster/views/__init__.py
@@ -310,7 +310,7 @@ def upload(request):
     if not default_storage.exists(preview_file_path):
         process_image(img, preview_file_path, fit_preview)
 
-    thumb = cropduster_image.save_size(size, standalone=True)
+    thumb = cropduster_image.save_size(size, standalone=True, commit=False)
 
     sizes = form_data.get('sizes') or []
     if len(sizes) == 1:
@@ -352,7 +352,12 @@ def crop(request):
                 log=True, exc_info=full_exc_info())
 
     crop_data = copy.deepcopy(crop_form.cleaned_data)
-    db_image = Image(image=crop_data['orig_image'])
+
+    if crop_data.get('image_id'):
+        db_image = Image.objects.get(pk=crop_data['image_id'])
+    else:
+        db_image = Image(image=crop_data['orig_image'])
+
     try:
         with db_image.image as f:
             f.open()

--- a/runtests.py
+++ b/runtests.py
@@ -7,6 +7,7 @@ class RunTests(selenosis.RunTests):
 
     def __call__(self, *args, **kwargs):
         warnings.simplefilter("error", Warning)
+        warnings.filterwarnings('ignore', message='.*?ckeditor')
         super(RunTests, self).__call__(*args, **kwargs)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,3 +27,5 @@ deps =
     dj111-grp: django-grappelli==2.10.2
     dj20-grp: django-grappelli==2.11.1
     dj21: https://github.com/django/django/archive/master.tar.gz
+    lxml
+    -e git+https://github.com/theatlantic/django-ckeditor.git@v4.5.7+atl.6.1#egg=django-ckeditor


### PR DESCRIPTION
We've always used the api of Thumb instances and ModelForms for standalone images (i.e., the images uploaded to cropduster from CKEditor)<sup>1</sup>, but we have never saved them to the database. By doing so, we allow ourselves to determine the user's crop selection from the database, rather than by reading it off of the file's XMP metadata, avoiding an unnecessary and expensive IO operation.

<sup>1</sup> These are called "standalone" images because they are not directly associated with another model instance; instead the `cropduster.Image` uses a `StandaloneImage` as its `content_object`—a minimal stub model—and all crop data is stored and read from the file's metadata.

**Note**: This PR won't populate the `Thumb` table with metadata from any existing `StandaloneImage` images; a separate script would be needed to do that.