### PR TITLE
Fix StandaloneImage.save() md5 hash generation

### DIFF
--- a/cropduster/migrations/0001_initial.py
+++ b/cropduster/migrations/0001_initial.py
@@ -40,7 +40,7 @@ class Migration(migrations.Migration):
             name='StandaloneImage',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('md5', models.CharField(max_length=32)),
+                ('md5', models.CharField(max_length=32, blank=True, default='')),
                 ('image', cropduster.fields.CropDusterImageField(blank=True, db_column='image', default='', upload_to='')),
             ],
             options={

--- a/cropduster/standalone/models.py
+++ b/cropduster/standalone/models.py
@@ -54,7 +54,7 @@ class StandaloneImage(models.Model):
 
     objects = StandaloneImageManager()
 
-    md5 = models.CharField(max_length=32)
+    md5 = models.CharField(max_length=32, blank=True, default='')
     image = CropDusterField(sizes=[Size("crop")], upload_to='')
 
     class Meta:
@@ -62,9 +62,10 @@ class StandaloneImage(models.Model):
         db_table = '%s_standaloneimage' % cropduster_settings.CROPDUSTER_DB_PREFIX
 
     def save(self, **kwargs):
-        if not self.md5:
+        if not self.md5 and self.image:
             md5_hash = hashlib.md5()
-            with default_open(self.image.path, mode='rb') as f:
+            with self.image.related_object.image as f:
+                f.open()
                 md5_hash.update(f.read())
-            self.md5 = md5_hash.digest()
+            self.md5 = md5_hash.hexdigest()
         super(StandaloneImage, self).save(**kwargs)


### PR DESCRIPTION
I stumbled upon this while trying to write some unit tests that required StandaloneImage instances. I think `default_open` was intended to be `default_storage.open`.