### PR TITLE
Fix upload bug when browser zoom is less than 100%

### DIFF
--- a/cropduster/static/cropduster/js/upload.js
+++ b/cropduster/static/cropduster/js/upload.js
@@ -387,7 +387,7 @@
                 clearTimeout(this.timeout);
                 this.timeout = undefined;
             }
-            if ($('#cropbox').width() > 1) {
+            if ($('#cropbox').prop('naturalWidth') > 1) {
                 this.onImageLoad();
                 return;
             }


### PR DESCRIPTION
To reproduce the bug:

1. open chrome and zoom out to some value less than 100%. Throttle the connection to "Slow 3G" speed in the Network tab of the Developer Console to ensure the image takes a while to be downloaded after the upload completes.
2. click "Upload Image" to open the cropduster upload modal. 
3. Set a breakpoint for the line changed in this PR, then upload an image

  https://github.com/theatlantic/django-cropduster/blob/d1a64b89dd50092c4febac8d7f81fc8d61482589/cropduster/static/cropduster/js/upload.js#L390

When the breakpoint is hit, the not-yet-loaded image should have a width and height greater than 1 (at 90% zoom, for instance, it is 1.11111). Jcrop is then initialized with dimensions of 1.11111x1.11111, which shows up as a tiny box to the user.

![screenshot](https://dl.dropbox.com/s/1yhkleb1n6srley/Screen%20Shot%202021-12-02%20at%202.27.45%20PM.png)