### PR TITLE
Use naturalWidth / naturalHeight to get jcrop box dimensions

### DIFF
--- a/cropduster/static/cropduster/js/upload.js
+++ b/cropduster/static/cropduster/js/upload.js
@@ -313,8 +313,8 @@
             }
 
             var options = {
-                boxWidth: $('#cropbox').width(),
-                boxHeight: $('#cropbox').height(),
+                boxWidth: $('#cropbox').prop('naturalWidth'),
+                boxHeight: $('#cropbox').prop('naturalHeight'),
                 minSize: calcMinSize(size),
                 trueSize: [this.orig_w, this.orig_h],
                 setSelect: this.getCropSelect(aspectRatio, aspectExtent),


### PR DESCRIPTION
I was able to reproduce the issue that's still being reported, and it looks like `$("#cropbox").width()` continues to return `1` even after the image has loaded and `$("#cropbox").prop("naturalWidth")` is returning the correct size.

I think this is not unrelated to the AWS outages. The surest way to reproduce the issue is to turn on network throttling in browser developer tools.